### PR TITLE
Adds namespace package declaration and basic Travis integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python: "3.5"
+install:
+  - "pip install -r requirements.txt"
+  - "pip install ."
+script:
+  - amazon/iontest/ion_test_driver.py --help

--- a/amazon/__init__.py
+++ b/amazon/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at:
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+
+__import__("pkg_resources").declare_namespace(__name__)


### PR DESCRIPTION
*Issue #, if available:*
#2 

*Description of changes:*
Explicitly declares the namespace package in an attempt to fix missing import errors. Adds a Travis hook to simply install and run the help command.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
