### PR TITLE
add ion-js to test-driver

### DIFF
--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -16,8 +16,8 @@
 
 Usage:
     ion_test_driver.py [--implementation <description>]... [--ion-tests <description>] [--test <type>]...
-                       [--local-only] [--cmake <path>] [--git <path>] [--maven <path>] [--java <path>]
-                       [--output-dir <dir>] [--results-file <file>] [<test_file>]...
+                       [--local-only] [--cmake <path>] [--git <path>] [--maven <path>] [--java <path>] [--npm <path>]
+                       [--node <path>] [--output-dir <dir>] [--results-file <file>] [<test_file>]...
     ion_test_driver.py (--list)
     ion_test_driver.py (-h | --help)
 
@@ -27,6 +27,10 @@ Options:
     --git <path>                        Path to the git executable.
 
     --maven <path>                      Path to the maven executable.
+
+    --npm <path>                        Path to npm executable.
+
+    --node <path>                       Path to the node executable.
 
     --java <path>                       Path to the java executable.
 

--- a/amazon/iontest/ion_test_driver_config.py
+++ b/amazon/iontest/ion_test_driver_config.py
@@ -29,6 +29,8 @@ TOOL_DEPENDENCIES = {
     'cmake': 'cmake',
     'git': 'git',
     'maven': 'mvn',
+    'npm': 'npm',
+    'node': 'node',
     'java': 'java'
 }
 
@@ -42,11 +44,19 @@ def install_ion_java(log):
     log_call(log, (TOOL_DEPENDENCIES['maven'], '-f', 'ion-java-cli/pom.xml', 'package'))
 
 
+def install_ion_js(log):
+    log_call(log, (TOOL_DEPENDENCIES['npm'], 'install', '--ignore-scripts'))
+    log_call(log, (TOOL_DEPENDENCIES['npm'], 'run-script', 'test-driver'))
+    log_call(log, (TOOL_DEPENDENCIES['npm'], 'run-script', 'build-test-driver'))
+
+
 ION_BUILDS = {
     'ion-c': IonBuild(install_ion_c, os.path.join('tools', 'cli', 'ion'), ()),
     'ion-tests': NO_OP_BUILD,
     'ion-java': IonBuild(install_ion_java, os.path.join('ion-java-cli', 'target', 'ion-java-cli-1.0.jar'),
-                         (TOOL_DEPENDENCIES['java'], "-jar"))
+                         (TOOL_DEPENDENCIES['java'], "-jar")),
+    'ion-js': IonBuild(install_ion_js, os.path.join('test-driver', 'dist', 'Cli.js'),
+                       (TOOL_DEPENDENCIES['node'],))
     # TODO add more implementations here
 }
 
@@ -54,6 +64,7 @@ ION_BUILDS = {
 # and should not be added here. For the proper description format, see the ion_test_driver CLI help.
 ION_IMPLEMENTATIONS = [
     'ion-c,https://github.com/amzn/ion-c.git,master',
-    'ion-java,https://github.com/amzn/ion-java,master'
+    'ion-java,https://github.com/amzn/ion-java,master',
+    'ion-js,https://github.com/amzn/ion-js.git,master'
     # TODO add more Ion implementations here
 ]


### PR DESCRIPTION
This PR is to add ion-js to test-driver.

**Tasks:**
1. added build tasks to create ion-js executable.
2. added command-line arguments for ion-js.
