### PR TITLE
Support tool-specific command to test the existence of the executable.

### DIFF
--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -92,9 +92,6 @@ def check_tool_dependencies(args):
             TOOL_DEPENDENCIES[name] = path
     for name, path in six.iteritems(TOOL_DEPENDENCIES):
         try:
-            # NOTE: if a tool dependency is added that doesn't have a `--help` command, the logic should be generalized
-            # to call a tool-specific command to test the existence of the executable. This should be a command that
-            # always returns zero.
             no_output = open(os.devnull, 'w')
             check_call([path, TOOL_TEST_COMMAND[name]], stdout=no_output, shell=COMMAND_SHELL)
         except:

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -71,8 +71,8 @@ from amazon.ion.simple_types import IonPySymbol, IonPyList
 from amazon.ion.util import Enum
 from docopt import docopt
 
-from amazon.iontest.ion_test_driver_config import TOOL_DEPENDENCIES, ION_BUILDS, ION_IMPLEMENTATIONS, ION_TESTS_SOURCE,\
-    RESULTS_FILE_DEFAULT
+from amazon.iontest.ion_test_driver_config import TOOL_DEPENDENCIES, ION_BUILDS, ION_IMPLEMENTATIONS, ION_TESTS_SOURCE, \
+    RESULTS_FILE_DEFAULT, TOOL_TEST_COMMAND
 from amazon.iontest.ion_test_driver_util import COMMAND_SHELL, log_call
 
 
@@ -96,7 +96,7 @@ def check_tool_dependencies(args):
             # to call a tool-specific command to test the existence of the executable. This should be a command that
             # always returns zero.
             no_output = open(os.devnull, 'w')
-            check_call([path, '--help'], stdout=no_output, shell=COMMAND_SHELL)
+            check_call([path, TOOL_TEST_COMMAND[name]], stdout=no_output, shell=COMMAND_SHELL)
         except:
             raise ValueError(name + " not found. Try specifying its location using --" + name + ".")
         finally:

--- a/amazon/iontest/ion_test_driver_config.py
+++ b/amazon/iontest/ion_test_driver_config.py
@@ -34,6 +34,16 @@ TOOL_DEPENDENCIES = {
     'java': 'java'
 }
 
+# command used for testing the existence of the executable
+TOOL_TEST_COMMAND = {
+    'cmake': '--help',
+    'git': '--help',
+    'maven': '--help',
+    'npm': '-v',
+    'node': '-v',
+    'java': '--help'
+}
+
 
 def install_ion_c(log):
     log_call(log, (TOOL_DEPENDENCIES['cmake'], '-DCMAKE_BUILD_TYPE=Debug'))


### PR DESCRIPTION
### Description:
We added a lot new dependencies, `--help` doesn't always return 0 for all of them. (e.g. npm --help will raise an error,  java 1.8 and java 14 have different cli)

### Example:
npm --help doesn't return 0:
![Screen Shot 2020-10-14 at 2 38 04 PM](https://user-images.githubusercontent.com/67451029/96048031-e480e580-0e2a-11eb-9e11-07210d6becda.png)

### Did for this PR:

I added a list so we can use a dependency specific command to test if a dependency exists.
