### PR TITLE
Updated GitHub Actions file spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ agrees with and what implementations the master commit starts to agree with.
 
 ### GitHub Actions files
 
-The GitHub Actions logic is under each implementation's `.github/workflow` directory. 
+The GitHub Actions logic is located in each implementation's `.github/workflow/ion-test-driver.yml`. 
 
 ### Workflow procedure
 

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -922,15 +922,6 @@ def validate_results(report, result_field, read_error, read_compare, write_error
 
 
 def replace_impl_name_for_message(obj, first_impl, second_impl):
-    """
-    Since we recognize the error type by message, so if two messages show the different texts, we treat them as
-    different errors. Some cli tools include implementations' name in the message field which will make ion-test-driver
-    treat two same issues differently. To avoid this, and make sure an implementation's revision number doesn't affect
-    analysis, we remove all revision number. For example ion-c_abcd1234 will be replaced by ion-c in the message field.
-    :param obj: The object including message field.
-    :param first_impl: first implementation's full name (e.g. ion-java_abcd123).
-    :param second_impl: second implementation's full name (e.g. ion-java_abcd123).
-    """
     if '_' not in first_impl or '_' not in second_impl or 'message' not in obj.keys():
         return
     obj['message'] = obj['message'].replace(first_impl, first_impl.split('_')[0])
@@ -938,6 +929,16 @@ def replace_impl_name_for_message(obj, first_impl, second_impl):
 
 
 def replace_impl_name_for_obj(errors, first_impl, second_impl):
+    """
+    Since we are able to recognize the error type using the message provided, if two messages show the different texts,
+    we will treat them as different errors. Some cli tools include the implementations' name in the message field which
+    will make the ion-test-driver treat the two issues differently even if they are the same. To avoid this, and to
+    make sure an implementation's revision number doesn't affect our analysis, we will remove all revision numbers.
+    For example, ion-c_abcd1234 will be replaced by ion-c in the message field.
+    :param errors: The list including multiple error objects.
+    :param first_impl: first implementation's full name (e.g. ion-java_abcd123).
+    :param second_impl: second implementation's full name (e.g. ion-java_abcd123).
+    """
     for error in errors:
         replace_impl_name_for_message(error, first_impl, second_impl)
 


### PR DESCRIPTION
I' made ion-test-driver to have its own file for GitHub Actions.

**the file struct now is:**
![Screen Shot 2020-11-03 at 10 02 46 AM](https://user-images.githubusercontent.com/67451029/98023414-bfddb500-1dbb-11eb-8964-9681befbc6e7.png)
where `main.yml` includes other build/test/deploy logic and `ion-test-driver.yml` focus on this test run.
By this way, I think it's more clearly to use/update in the future. 

**Example:**
Even though they are in the different files, the workflow running is same as before, here is an example run in my ion-java local repo, I'm still working on migrating travis to GH actions but it runs successfully with multiple files(job `build` and `ion-test-driver` are in two different files) [PR](https://github.com/cheqianh/ion-java/pull/28/checks?check_run_id=1346271569).

If you think it's a good idea:
I renamed ion-c in PR [here](https://github.com/amzn/ion-c/compare/spec?expand=1). 
ion-java will match this spec after I migrate CI/CD from Travis to GH actions. 
so does ion-js.

**Note:**
The other paragraph in this PR is the comment that I wrote from last PR. I moved it to the wrapper function.
 
