### PR TITLE
Added a new option that allows user to specify the default description.

### DIFF
--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -17,7 +17,7 @@
 Usage:
     ion_test_driver.py [--implementation <description>]... [--ion-tests <description>] [--test <type>]...
                        [--local-only] [--cmake <path>] [--git <path>] [--maven <path>] [--java <path>] [--npm <path>]
-                       [--node <path>] [--output-dir <dir>] [--results-file <file>] [--replace <desc>]
+                       [--node <path>] [--output-dir <dir>] [--results-file <file>] [--replace <description>]
                        [<test_file>]...
     ion_test_driver.py --results-diff <first_description> <second_description> <results_file> [--output-dir <dir>]
     ion_test_driver.py (--list)

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -17,7 +17,7 @@
 Usage:
     ion_test_driver.py [--implementation <description>]... [--ion-tests <description>] [--test <type>]...
                        [--local-only] [--cmake <path>] [--git <path>] [--maven <path>] [--java <path>] [--npm <path>]
-                       [--node <path>] [--output-dir <dir>] [--results-file <file>] [--specific-desc <desc>]
+                       [--node <path>] [--output-dir <dir>] [--results-file <file>] [--replace <desc>]
                        [<test_file>]...
     ion_test_driver.py --results-diff <first_description> <second_description> <results_file> [--output-dir <dir>]
     ion_test_driver.py (--list)
@@ -64,7 +64,7 @@ Options:
                                         The order of two implementations matters and the analysis result is based on the
                                         first implementation.
 
-    -s, --specific-desc <description>   Replace a default implementation by the specific description.
+    --replace <description>             Replace a default implementation by the specific description.
 
     -t, --test <type>                   Perform a particular test type or types, chosen from `good`, `bad`, `equivs`,
                                         `non-equivs`, and `all`. [default: all]
@@ -753,8 +753,7 @@ def parse_implementations(descriptions, output_root):
 
 
 def replace_default_impl(desc):
-    desc_array = desc.split(',')
-    name = desc_array[0]
+    name = desc.split(',')[0]
     for i in range(len(ION_IMPLEMENTATIONS)):
         if ION_IMPLEMENTATIONS[i].split(',')[0] == name:
             ION_IMPLEMENTATIONS[i] = desc
@@ -1202,8 +1201,8 @@ def ion_test_driver(arguments):
         if not os.path.exists(output_root):
             os.makedirs(output_root)
         implementations = parse_implementations(arguments['--implementation'], output_root)
-        if arguments['--specific-desc']:
-            replace_default_impl(arguments['--specific-desc'])
+        if arguments['--replace']:
+            replace_default_impl(arguments['--replace'])
         if not arguments['--local-only']:
             implementations += parse_implementations(ION_IMPLEMENTATIONS, output_root)
         check_tool_dependencies(arguments)

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -17,7 +17,8 @@
 Usage:
     ion_test_driver.py [--implementation <description>]... [--ion-tests <description>] [--test <type>]...
                        [--local-only] [--cmake <path>] [--git <path>] [--maven <path>] [--java <path>] [--npm <path>]
-                       [--node <path>] [--output-dir <dir>] [--results-file <file>] [<test_file>]...
+                       [--node <path>] [--output-dir <dir>] [--results-file <file>] [--specific-desc <desc>]
+                       [<test_file>]...
     ion_test_driver.py --results-diff <first_description> <second_description> <results_file> [--output-dir <dir>]
     ion_test_driver.py (--list)
     ion_test_driver.py (-h | --help)
@@ -62,6 +63,8 @@ Options:
                                         results file to identify any differences between the two implementations.
                                         The order of two implementations matters and the analysis result is based on the
                                         first implementation.
+
+    -s, --specific-desc <description>   Replace a default implementation by the specific description.
 
     -t, --test <type>                   Perform a particular test type or types, chosen from `good`, `bad`, `equivs`,
                                         `non-equivs`, and `all`. [default: all]
@@ -749,6 +752,14 @@ def parse_implementations(descriptions, output_root):
             for description in descriptions]
 
 
+def replace_default_impl(desc):
+    desc_array = desc.split(',')
+    name = desc_array[0]
+    for i in range(len(ION_IMPLEMENTATIONS)):
+        if ION_IMPLEMENTATIONS[i].split(',')[0] == name:
+            ION_IMPLEMENTATIONS[i] = desc
+
+
 def write_errors(report, first_field, first_report, second_field, second_report, field, msg):
     report[TestFile.ERROR_MESSAGE_FIELD] = msg
     errors = {}
@@ -1191,8 +1202,12 @@ def ion_test_driver(arguments):
         if not os.path.exists(output_root):
             os.makedirs(output_root)
         implementations = parse_implementations(arguments['--implementation'], output_root)
+        if arguments['--specific-desc']:
+            print(arguments['--specific-desc'])
+            replace_default_impl(arguments['--specific-desc'])
         if not arguments['--local-only']:
             implementations += parse_implementations(ION_IMPLEMENTATIONS, output_root)
+        print(ION_IMPLEMENTATIONS)
         check_tool_dependencies(arguments)
         for implementation in implementations:
             implementation.install()

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -1203,11 +1203,9 @@ def ion_test_driver(arguments):
             os.makedirs(output_root)
         implementations = parse_implementations(arguments['--implementation'], output_root)
         if arguments['--specific-desc']:
-            print(arguments['--specific-desc'])
             replace_default_impl(arguments['--specific-desc'])
         if not arguments['--local-only']:
             implementations += parse_implementations(ION_IMPLEMENTATIONS, output_root)
-        print(ION_IMPLEMENTATIONS)
         check_tool_dependencies(arguments)
         for implementation in implementations:
             implementation.install()

--- a/amazon/iontest/ion_test_driver_config.py
+++ b/amazon/iontest/ion_test_driver_config.py
@@ -78,3 +78,4 @@ ION_IMPLEMENTATIONS = [
     'ion-js,https://github.com/amzn/ion-js.git,master'
     # TODO add more Ion implementations here
 ]
+

--- a/amazon/iontest/ion_test_driver_config.py
+++ b/amazon/iontest/ion_test_driver_config.py
@@ -78,4 +78,3 @@ ION_IMPLEMENTATIONS = [
     'ion-js,https://github.com/amzn/ion-js.git,master'
     # TODO add more Ion implementations here
 ]
-


### PR DESCRIPTION
Added the feature that allows ion-test-driver to replace a default implementation.

For example, ion-test-driver will run ion-java, master as default. We can now replace it to the specific revision.
