### PR TITLE
Adds retrying for setup work.

### DIFF
--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -1212,7 +1212,7 @@ def ion_test_driver(arguments):
                     implementation.install()
                 break
             except Exception as e:
-                if n is not RETRY_TIME - 1:
+                if n < RETRY_TIME - 1:
                     print('Retry installation, attempts: %d.' % (n + 1))
                     continue
                 else:

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -85,7 +85,7 @@ from amazon.ion.util import Enum
 from docopt import docopt
 
 from amazon.iontest.ion_test_driver_config import TOOL_DEPENDENCIES, ION_BUILDS, ION_IMPLEMENTATIONS, ION_TESTS_SOURCE, \
-    RESULTS_FILE_DEFAULT, TOOL_TEST_COMMAND, RETRY_TIME
+    RESULTS_FILE_DEFAULT, TOOL_TEST_COMMAND, RETRY_ATTEMPTS
 from amazon.iontest.ion_test_driver_util import COMMAND_SHELL, log_call
 
 
@@ -1206,13 +1206,13 @@ def ion_test_driver(arguments):
         if not arguments['--local-only']:
             implementations += parse_implementations(ION_IMPLEMENTATIONS, output_root)
         check_tool_dependencies(arguments)
-        for n in range(RETRY_TIME):
+        for n in range(RETRY_ATTEMPTS):
             try:
                 for implementation in implementations:
                     implementation.install()
                 break
             except Exception as e:
-                if n < RETRY_TIME - 1:
+                if n < RETRY_ATTEMPTS - 1:
                     print('Retry installation, attempts: %d.' % (n + 1))
                     continue
                 else:

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -85,7 +85,7 @@ from amazon.ion.util import Enum
 from docopt import docopt
 
 from amazon.iontest.ion_test_driver_config import TOOL_DEPENDENCIES, ION_BUILDS, ION_IMPLEMENTATIONS, ION_TESTS_SOURCE, \
-    RESULTS_FILE_DEFAULT, TOOL_TEST_COMMAND
+    RESULTS_FILE_DEFAULT, TOOL_TEST_COMMAND, RETRY_TIME
 from amazon.iontest.ion_test_driver_util import COMMAND_SHELL, log_call
 
 
@@ -1206,8 +1206,17 @@ def ion_test_driver(arguments):
         if not arguments['--local-only']:
             implementations += parse_implementations(ION_IMPLEMENTATIONS, output_root)
         check_tool_dependencies(arguments)
-        for implementation in implementations:
-            implementation.install()
+        for n in range(RETRY_TIME):
+            try:
+                for implementation in implementations:
+                    implementation.install()
+                break
+            except Exception as e:
+                if n is not RETRY_TIME - 1:
+                    print('Retry installation, attempts: %d.' % (n + 1))
+                    continue
+                else:
+                    raise e
         ion_tests_source = arguments['--ion-tests']
         if not ion_tests_source:
             ion_tests_source = ION_TESTS_SOURCE

--- a/amazon/iontest/ion_test_driver_config.py
+++ b/amazon/iontest/ion_test_driver_config.py
@@ -22,6 +22,7 @@ from amazon.iontest.ion_test_driver_util import IonBuild, NO_OP_BUILD, log_call
 
 RESULTS_FILE_DEFAULT = 'ion-test-driver-results.ion'
 ION_TESTS_SOURCE = 'https://github.com/amzn/ion-tests.git'
+RETRY_TIME = 2
 
 # Tools expected to be present on the system. Key: name, value: path. Paths may be overridden using --<name>.
 # Accordingly, if tool dependencies are added here, a corresponding option should be added to the CLI.

--- a/amazon/iontest/ion_test_driver_config.py
+++ b/amazon/iontest/ion_test_driver_config.py
@@ -22,7 +22,7 @@ from amazon.iontest.ion_test_driver_util import IonBuild, NO_OP_BUILD, log_call
 
 RESULTS_FILE_DEFAULT = 'ion-test-driver-results.ion'
 ION_TESTS_SOURCE = 'https://github.com/amzn/ion-tests.git'
-RETRY_TIME = 2
+RETRY_ATTEMPTS = 2
 
 # Tools expected to be present on the system. Key: name, value: path. Paths may be overridden using --<name>.
 # Accordingly, if tool dependencies are added here, a corresponding option should be added to the CLI.


### PR DESCRIPTION
### Description 
Added retry logic for setup step where npm run into issue. It will retry `RETRY_TIME` times.

If the npm error is a dependency issue, this retry may not fix it and we still need to re-run the workflow to initialize all the dependencies on the container. However, having a retry logic still can handle a lot of unexpected issues.

### Test example: 
Suppose that ion-java has an installation issue, it retries when it run into error the first time and throw the exception after `RETRY_TIME` attempts.
![Screen Shot 2021-06-16 at 12 26 40 PM](https://user-images.githubusercontent.com/67451029/122280506-1e185d80-ce9e-11eb-9e8d-e56978364b62.png)





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
