### PR TITLE
Update ion-python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.6']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.6']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ py==1.10.0
 pytest==6.1.1
 pytest-runner==2.8
 six==1.10.0
-amazon.ion==0.7.0
+amazon.ion==0.9.3
 docopt==0.6.2


### PR DESCRIPTION
This commit updates ion-python to a more recent version.

This is motivated by the fact that versions prior to 0.9.x do not work with
python 3.10.

It also updates the build to run against python 3.10 to test that.